### PR TITLE
Fix regex in `PageSubscriber.php`

### DIFF
--- a/app/bundles/PageBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PageSubscriber.php
@@ -161,7 +161,7 @@ class PageSubscriber implements EventSubscriberInterface
         $bodyOpenScripts = ob_get_clean();
 
         if ($bodyOpenScripts) {
-            preg_match('/(<body[a-z=\s\-_:"\']*>)/i', $content, $matches);
+            preg_match('/(<body[^>]*>)/i', $content, $matches);
 
             $content = str_ireplace($matches[0], $matches[0]."\n".$bodyOpenScripts, $content);
         }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The regex in `onPageDisplay()` for the `onPageDisplay_bodyOpen` event for outputting the `bodyOpenScripts` is faulty and won't catch all possible scenarios.

See this regex tester with real world scenarios (and sources):
https://regex101.com/r/fXmrq6/1

See that this fix fixes this:
https://regex101.com/r/W7bwDL/3

**Additional Ressources**
- https://www.rexegg.com/regex-style.html#contrast
- https://www.rexegg.com/regex-style.html#lazy_warning
- https://www.rexegg.com/regex-quantifiers.html#negclass_solution
